### PR TITLE
Resolving class thresholding mismatch (8 -> 15) in kitti.py

### DIFF
--- a/task_adaptation/data/kitti.py
+++ b/task_adaptation/data/kitti.py
@@ -30,7 +30,7 @@ def _count_all_pp(x):
   """Count all objects."""
   # Count distribution (thresholded at 15):
 
-  label = tf.math.minimum(tf.size(x["objects"]["type"]) - 1, 8)
+  label = tf.math.minimum(tf.size(x["objects"]["type"]) - 1, 15)
   return {"image": x["image"], "label": label}
 
 
@@ -50,7 +50,7 @@ def _count_left_pp(x):
 
   # Location feature contains (x, y, z) in meters w.r.t. the camera.
   objects_on_left = tf.where(x["objects"]["location"][:, 0] < 0)
-  label = tf.math.minimum(tf.size(objects_on_left), 8)
+  label = tf.math.minimum(tf.size(objects_on_left), 15)
   return {"image": x["image"], "label": label}
 
 
@@ -61,7 +61,7 @@ def _count_far_pp(x):
 
   # Location feature contains (x, y, z) in meters w.r.t. the camera.
   distant_objects = tf.where(x["objects"]["location"][:, 2] >= 25)
-  label = tf.math.minimum(tf.size(distant_objects), 8)
+  label = tf.math.minimum(tf.size(distant_objects), 15)
   return {"image": x["image"], "label": label}
 
 
@@ -72,7 +72,7 @@ def _count_near_pp(x):
 
   # Location feature contains (x, y, z) in meters w.r.t. the camera.
   close_objects = tf.where(x["objects"]["location"][:, 2] < 25)
-  label = tf.math.minimum(tf.size(close_objects), 8)
+  label = tf.math.minimum(tf.size(close_objects), 15)
   return {"image": x["image"], "label": label}
 
 


### PR DESCRIPTION
For the preprocess function _count_all_pp(), _count_left_pp(), _count_far_pp(), and _count_near_pp(), the comment says they will be thresholded at 15, and later these tasks all have 16 labels. However, in the code they are actually thresholded at 8, leading to 9 classes. I have changed 8 -> 15 to mach the comment as well as the class numbers.